### PR TITLE
Fix Docker image instruction

### DIFF
--- a/docker/base/nodejs-dockerfile
+++ b/docker/base/nodejs-dockerfile
@@ -2,5 +2,5 @@ FROM node:8
 
 RUN apt-get update \
     && apt-get install -y ruby-full rubygems \
-    && gem instal sass
-RUN npm install --unsafe-perm -g gulp node-sass
+    && gem install sass
+RUN npm install --unsafe-perm -g gulp node-sass@4.14.1


### PR DESCRIPTION
## What Happened

There was a typo to install a gem and node-sass@5.0.0 (latest) is incompatible with Node 8 so the frontend app must remain on 4.x.x

## Insights

The new version of node-sass was released very recently which might explain why the repository of OpenLoyalty has not been updated.

![image](https://user-images.githubusercontent.com/696529/98229286-4d6fff00-1f8c-11eb-9ac4-90ac07764d10.png)

## Proof of Work

The local images can be built successfully:

![image](https://user-images.githubusercontent.com/696529/98229508-92943100-1f8c-11eb-9d57-fb7dd155a61e.png)
